### PR TITLE
Only install dependencies if they don't exist

### DIFF
--- a/src/ftp.rs
+++ b/src/ftp.rs
@@ -184,7 +184,8 @@ impl FtpClient {
         self.send("TYPE I")?;
 
         //self.next_line()?);
-        self.expect_success()?;
+        //self.expect_success()?;
+        self.clear_status();
 
         let (_ip, mut channel) = self.open_passive_channel()?;
 

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -95,16 +95,19 @@ pub fn install(ip: Option<String>, title_id: Option<String>, release: bool) -> R
     }
 
     for dep in &metadata.plugin_dependencies {
-        println!("Downloading dependency {}...", dep.name);
-        let dep_data =
-            attohttpc::get(&dep.url).send()
-                .map_err(|_| Error::DownloadError)?
-                .bytes().map_err(|_| Error::DownloadError)?;
-        println!("Installing dependency {}...", dep.name);
-        client.put(
-            &format!("{}/{}", dir_path, dep.name),
-            &dep_data
-        ).unwrap();
+        let dep_path = &format!("{}/{}", dir_path, dep.name);
+        if !client.file_exists(dep_path).unwrap_or(false) {
+            println!("Downloading dependency {}...", dep.name);
+            let dep_data =
+                attohttpc::get(&dep.url).send()
+                    .map_err(|_| Error::DownloadError)?
+                    .bytes().map_err(|_| Error::DownloadError)?;
+            println!("Installing dependency {}...", dep.name);
+            client.put(
+                dep_path,
+                &dep_data
+            ).unwrap();
+        }
     }
 
     let nro_name = nro_path.file_name().map(|x| x.to_str()).flatten().ok_or(Error::FailWriteNro)?;


### PR DESCRIPTION
Tested locally, has expected behavior.

```zsh
➜  skyline-rs-template git:(master) ✗ cargo skyline install
    Finished release [optimized] target(s) in 0.05s.
Connected!
Ensuring directory exists...
Downloading dependency libacmd_hook.nro...
Installing dependency libacmd_hook.nro...
Transferring file...
➜  skyline-rs-template git:(master) ✗ cargo skyline install
    Finished release [optimized] target(s) in 0.05s
Connected!
Ensuring directory exists...
Transferring file...
```