### PR TITLE
edit rm/ls functionality, add copy

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,8 @@ pub enum Error {
     IoError(io::Error),
     FtpError(FtpError),
     CargoError(cargo_metadata::Error),
-    ExitStatus(i32)
+    ExitStatus(i32),
+    AbsSwitchPath
 }
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/game_paths.rs
+++ b/src/game_paths.rs
@@ -1,5 +1,9 @@
-pub fn get_plugin_path(title_id: &str) -> String {
+pub fn get_plugins_path(title_id: &str) -> String {
     format!("/atmosphere/contents/{}/romfs/skyline/plugins", title_id)
+}
+
+pub fn get_plugin_path(title_id: &str, plugin_name: &str) -> String {
+    format!("/atmosphere/contents/{}/romfs/skyline/plugins/{}", title_id, plugin_name)
 }
 
 pub fn get_game_path(title_id: &str) -> String {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -198,12 +198,18 @@ pub fn rm(ip: Option<String>, title_id: Option<String>, filename: Option<String>
     Ok(())
 }
 
+// for now, we assume src is local and dest is Switch
 pub fn cp(ip: Option<String>, title_id: Option<String>, src: String, dest: String) -> Result<()> {
     let ip = verify_ip(get_ip(ip)?)?;
 
     let mut client = connect(ip, false)?;
 
-    let dest_path = PathBuf::from(&dest);
+    // TODO: remove once two-way CP is supported
+    if dest.starts_with("/") {
+        return Err(Error::AbsSwitchPath);
+    }
+
+    let dest_path = PathBuf::from(&dest.replace("sd:/", "/"));
 
     let mut install_path = get_install_path(title_id, Some(dest_path.to_str().unwrap().to_string()))?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,7 @@ fn main() {
             Error::DownloadError => eprintln!("{}: Failed to download latest release of Skyline. An internet connection is required.", "ERROR".red()),
             Error::ZipError => eprintln!("{}: Failed to read Skyline release zip. Either corrupted or missing files.", "ERROR".red()),
             Error::NoNpdmFileFound => eprintln!("{}: Custom NPDM file specified in Cargo.toml not found at the specified path.", "ERROR".red()),
+            Error::AbsSwitchPath => eprintln!("{}: Absolute Switch paths must be prepended with \"sd:/\"", "ERROR".red()),
         }
 
         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,9 @@ enum SubCommands {
             short, long,
             about = "Title ID of the game to list the installed plugins for, can be overriden in Cargo.toml",
         )]
-        title_id: Option<String>
+        title_id: Option<String>,
+
+        path: Option<String>
     },
     #[structopt(about = "Delete a file in the plugin directory for the given game")]
     Rm {
@@ -114,11 +116,22 @@ enum SubCommands {
         )]
         title_id: Option<String>,
 
+        filename: Option<String>
+    },
+    #[structopt(about = "Copy a file over FTP")]
+    Cp {
+        #[structopt(short, long)]
+        ip: Option<String>,
+
         #[structopt(
             short, long,
-            about = "Filename of the plugin to delete",
+            about = "Title ID of the game to list the installed plugins for, can be overriden in Cargo.toml",
         )]
-        filename: Option<String>
+        title_id: Option<String>,
+
+        src: String,
+        
+        dest: String
     },
     #[structopt(about = "Update cargo-skyline command")]
     SelfUpdate {
@@ -185,8 +198,9 @@ fn main() {
         New { name, template_git, template_git_branch } => git_clone_wrappers::new_plugin(name, template_git, template_git_branch),
         UpdateStd { git, std_path } => git_clone_wrappers::update_std(git, std_path),
         Listen { ip } => tcp_listen::listen(ip),
-        List { ip, title_id } => installer::list(ip, title_id),
+        List { ip, title_id, path } => installer::list(ip, title_id, path),
         Rm { ip, title_id, filename } => installer::rm(ip, title_id, filename),
+        Cp { ip, title_id, src, dest } => installer::cp(ip, title_id, src, dest),
         SelfUpdate { from_master, git } => self_update(from_master, git),
         Package { skyline_release, title_id, out_path }
             => package::package(&skyline_release, title_id.as_deref(), &out_path),


### PR DESCRIPTION
Refactored/added `rm, ls, cp` functionality so we can use absolute paths as well as paths relative to the plugin directory to use `cargo skyline` as an FTP client for the Switch in general. This could be very useful in integrating with other workflows (i.e., Tesla menuing or other systems)

`cp` currently only goes one direction, from local to the Switch.

Tested with various cases, including installation.

```
➜  cargo-skyline git:(master) ✗ cargo skyline cp hello.txt /switch/.overlays
Transferring file to /switch/.overlays/hello.txt...
➜  cargo-skyline git:(master) ✗ cargo skyline list /switch/.overlays        
-rw-rw-rw- 1 3DS 3DS 395461 May 15 2020 ovlmenu.ovl
-rw-rw-rw- 1 3DS 3DS 397368 Aug 10 2020 ovlTrainingModpack.ovl
-rw-rw-rw- 1 3DS 3DS 370885 Jun 16 2020 ovlEdiZon.ovl
-rw-rw-rw- 1 3DS 3DS 5 Aug 13 2020 hello.txt

➜  cargo-skyline git:(master) ✗ cargo skyline rm /switch/.overlays/hello.txt
/switch/.overlays/hello.txt
➜  cargo-skyline git:(master) ✗ cargo skyline list /switch/.overlays        
-rw-rw-rw- 1 3DS 3DS 395461 May 15 2020 ovlmenu.ovl
-rw-rw-rw- 1 3DS 3DS 397368 Aug 10 2020 ovlTrainingModpack.ovl
-rw-rw-rw- 1 3DS 3DS 370885 Jun 16 2020 ovlEdiZon.ovl
```