### PR TITLE
Support --install-path

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -23,7 +23,8 @@ pub enum Error {
     FtpError(FtpError),
     CargoError(cargo_metadata::Error),
     ExitStatus(i32),
-    AbsSwitchPath
+    AbsSwitchPath,
+    BadSdPath
 }
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/game_paths.rs
+++ b/src/game_paths.rs
@@ -2,16 +2,8 @@ pub fn get_plugins_path(title_id: &str) -> String {
     format!("/atmosphere/contents/{}/romfs/skyline/plugins", title_id)
 }
 
-pub fn get_plugin_path(title_id: &str, plugin_name: &str, user_path: Option<String>) -> String {
-    if let Some(user_path) = user_path {
-        if user_path.starts_with("/") {
-            format!("/atmosphere/contents/{}/romfs{}", title_id, user_path)
-        } else {
-            format!("/atmosphere/contents/{}/romfs/{}", title_id, user_path)
-        }
-    } else {
-        format!("/atmosphere/contents/{}/romfs/skyline/plugins/{}", title_id, plugin_name)
-    }
+pub fn get_plugin_path(title_id: &str, plugin_name: &str) -> String {
+    format!("/atmosphere/contents/{}/romfs/skyline/plugins/{}", title_id, plugin_name)
 }
 
 pub fn get_game_path(title_id: &str) -> String {

--- a/src/game_paths.rs
+++ b/src/game_paths.rs
@@ -2,8 +2,16 @@ pub fn get_plugins_path(title_id: &str) -> String {
     format!("/atmosphere/contents/{}/romfs/skyline/plugins", title_id)
 }
 
-pub fn get_plugin_path(title_id: &str, plugin_name: &str) -> String {
-    format!("/atmosphere/contents/{}/romfs/skyline/plugins/{}", title_id, plugin_name)
+pub fn get_plugin_path(title_id: &str, plugin_name: &str, user_path: Option<String>) -> String {
+    if let Some(user_path) = user_path {
+        if user_path.starts_with("/") {
+            format!("/atmosphere/contents/{}/romfs{}", title_id, user_path)
+        } else {
+            format!("/atmosphere/contents/{}/romfs/{}", title_id, user_path)
+        }
+    } else {
+        format!("/atmosphere/contents/{}/romfs/skyline/plugins/{}", title_id, plugin_name)
+    }
 }
 
 pub fn get_game_path(title_id: &str) -> String {

--- a/src/installer.rs
+++ b/src/installer.rs
@@ -143,10 +143,10 @@ pub fn install(ip: Option<String>, title_id: Option<String>, release: bool, feat
     Ok(())
 }
 
-pub fn from_git(git: &str, ip: Option<String>, title_id: Option<String>, release: bool, features: Vec<String>) -> Result<()> {
+pub fn from_git(git: &str, ip: Option<String>, title_id: Option<String>, release: bool, features: Vec<String>, path: Option<String>) -> Result<()> {
     let temp_dir = TempGitDir::clone_to_current_dir(git)?;
 
-    install(ip, title_id, release, features, None)?;
+    install(ip, title_id, release, features, path)?;
 
     temp_dir.delete();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,9 @@ enum SubCommands {
 
         #[structopt(long)]
         features: Vec<String>,
+
+        #[structopt(long)]
+        path: Option<String>
     },
     #[structopt(about = "Set the IP address of the switch to install to")]
     SetIp {
@@ -98,6 +101,9 @@ enum SubCommands {
 
         #[structopt(long)]
         features: Vec<String>,
+
+        #[structopt(long)]
+        path: Option<String>
     },
     #[structopt(about = "Install the current plugin and listen for skyline logging")]
     Restart {
@@ -217,17 +223,17 @@ fn main() {
     use SubCommands::*;
 
     let result = match subcommand {
-        Install { ip, title_id, debug, git, features } => if let Some(git) = git {
+        Install { ip, title_id, debug, git, features , path} => if let Some(git) = git {
             installer::from_git(&git, ip, title_id, !debug, features)
         } else {
-            installer::install(ip, title_id, !debug, features)
+            installer::install(ip, title_id, !debug, features, path)
         },
         SetIp { ip } => ip_addr::set_ip(ip),
         ShowIp => ip_addr::show_ip(),
         Build { args, release, nso, features } => build::build(args, release, nso, features),
         Check => build::check(),
         Clippy => build::clippy(),
-        Run { ip, title_id, debug, restart , features} => installer::install_and_run(ip, title_id, !debug, restart, features),
+        Run { ip, title_id, debug, restart , features, path} => installer::install_and_run(ip, title_id, !debug, restart, features, path),
         Restart { ip, title_id } => installer::restart_game(ip, title_id),
         New { name, template_git, template_git_branch } => git_clone_wrappers::new_plugin(name, template_git, template_git_branch),
         UpdateStd { git, std_path } => git_clone_wrappers::update_std(git, std_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ enum SubCommands {
         features: Vec<String>,
 
         #[structopt(long)]
-        root: Option<String>
+        install_path: Option<String>
     },
     #[structopt(about = "Set the IP address of the switch to install to")]
     SetIp {
@@ -103,7 +103,7 @@ enum SubCommands {
         features: Vec<String>,
 
         #[structopt(long)]
-        root: Option<String>
+        install_path: Option<String>
     },
     #[structopt(about = "Install the current plugin and listen for skyline logging")]
     Restart {
@@ -223,17 +223,17 @@ fn main() {
     use SubCommands::*;
 
     let result = match subcommand {
-        Install { ip, title_id, debug, git, features , root} => if let Some(git) = git {
-            installer::from_git(&git, ip, title_id, !debug, features, root)
+        Install { ip, title_id, debug, git, features , install_path} => if let Some(git) = git {
+            installer::from_git(&git, ip, title_id, !debug, features, install_path)
         } else {
-            installer::install(ip, title_id, !debug, features, root)
+            installer::install(ip, title_id, !debug, features, install_path)
         },
         SetIp { ip } => ip_addr::set_ip(ip),
         ShowIp => ip_addr::show_ip(),
         Build { args, release, nso, features } => build::build(args, release, nso, features),
         Check => build::check(),
         Clippy => build::clippy(),
-        Run { ip, title_id, debug, restart , features, root} => installer::install_and_run(ip, title_id, !debug, restart, features, root),
+        Run { ip, title_id, debug, restart , features, install_path} => installer::install_and_run(ip, title_id, !debug, restart, features, install_path),
         Restart { ip, title_id } => installer::restart_game(ip, title_id),
         New { name, template_git, template_git_branch } => git_clone_wrappers::new_plugin(name, template_git, template_git_branch),
         UpdateStd { git, std_path } => git_clone_wrappers::update_std(git, std_path),
@@ -274,6 +274,7 @@ fn main() {
             Error::ZipError => eprintln!("{}: Failed to read Skyline release zip. Either corrupted or missing files.", "ERROR".red()),
             Error::NoNpdmFileFound => eprintln!("{}: Custom NPDM file specified in Cargo.toml not found at the specified path.", "ERROR".red()),
             Error::AbsSwitchPath => eprintln!("{}: Absolute Switch paths must be prepended with \"sd:/\"", "ERROR".red()),
+            Error::BadSdPath => eprintln!("{}: Install paths must either start with \"rom:/\" or \"sd:/\"", "ERROR".red())
         }
 
         std::process::exit(1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ enum SubCommands {
         features: Vec<String>,
 
         #[structopt(long)]
-        path: Option<String>
+        root: Option<String>
     },
     #[structopt(about = "Set the IP address of the switch to install to")]
     SetIp {
@@ -103,7 +103,7 @@ enum SubCommands {
         features: Vec<String>,
 
         #[structopt(long)]
-        path: Option<String>
+        root: Option<String>
     },
     #[structopt(about = "Install the current plugin and listen for skyline logging")]
     Restart {
@@ -223,8 +223,8 @@ fn main() {
     use SubCommands::*;
 
     let result = match subcommand {
-        Install { ip, title_id, debug, git, features , path} => if let Some(git) = git {
-            installer::from_git(&git, ip, title_id, !debug, features)
+        Install { ip, title_id, debug, git, features , root} => if let Some(git) = git {
+            installer::from_git(&git, ip, title_id, !debug, features, path)
         } else {
             installer::install(ip, title_id, !debug, features, path)
         },
@@ -233,7 +233,7 @@ fn main() {
         Build { args, release, nso, features } => build::build(args, release, nso, features),
         Check => build::check(),
         Clippy => build::clippy(),
-        Run { ip, title_id, debug, restart , features, path} => installer::install_and_run(ip, title_id, !debug, restart, features, path),
+        Run { ip, title_id, debug, restart , features, root} => installer::install_and_run(ip, title_id, !debug, restart, features, path),
         Restart { ip, title_id } => installer::restart_game(ip, title_id),
         New { name, template_git, template_git_branch } => git_clone_wrappers::new_plugin(name, template_git, template_git_branch),
         UpdateStd { git, std_path } => git_clone_wrappers::update_std(git, std_path),

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,16 +224,16 @@ fn main() {
 
     let result = match subcommand {
         Install { ip, title_id, debug, git, features , root} => if let Some(git) = git {
-            installer::from_git(&git, ip, title_id, !debug, features, path)
+            installer::from_git(&git, ip, title_id, !debug, features, root)
         } else {
-            installer::install(ip, title_id, !debug, features, path)
+            installer::install(ip, title_id, !debug, features, root)
         },
         SetIp { ip } => ip_addr::set_ip(ip),
         ShowIp => ip_addr::show_ip(),
         Build { args, release, nso, features } => build::build(args, release, nso, features),
         Check => build::check(),
         Clippy => build::clippy(),
-        Run { ip, title_id, debug, restart , features, root} => installer::install_and_run(ip, title_id, !debug, restart, features, path),
+        Run { ip, title_id, debug, restart , features, root} => installer::install_and_run(ip, title_id, !debug, restart, features, root),
         Restart { ip, title_id } => installer::restart_game(ip, title_id),
         New { name, template_git, template_git_branch } => git_clone_wrappers::new_plugin(name, template_git, template_git_branch),
         UpdateStd { git, std_path } => git_clone_wrappers::update_std(git, std_path),


### PR DESCRIPTION
In this case the path is supposed to end with the plugin name and is local to the romfs. For example
```
cargo skyline install --root smashline/development.nro
```
would build/install the plugin to `sd:/atmosphere/contents/<titleid>/romfs/smashline/development.nro`

originally the arg name was `--path` but ig cargo uses `--root` for this purpose instead? if it's the wrong name it's easy to change