### PR TITLE
remove git history on new project

### DIFF
--- a/src/git_clone_wrappers.rs
+++ b/src/git_clone_wrappers.rs
@@ -38,6 +38,8 @@ pub fn new_plugin(name: String, git_url: String, git_branch: String) -> Result<(
             replace(&format!("{}/{}", name, path), "skyline_rs_template", &name)?;
         }
 
+        fs::remove_dir_all(&format!("{}/.git", name))?;
+
         let _ = fs::remove_file(&format!("{}/{}", name, ".github/workflows/rustdoc.yml"));
     }
 

--- a/src/git_clone_wrappers.rs
+++ b/src/git_clone_wrappers.rs
@@ -38,7 +38,7 @@ pub fn new_plugin(name: String, git_url: String, git_branch: String) -> Result<(
             replace(&format!("{}/{}", name, path), "skyline_rs_template", &name)?;
         }
 
-        fs::remove_dir_all(&format!("{}/.git", name))?;
+        let _ = fs::remove_dir_all(&format!("{}/.git", name));
 
         let _ = fs::remove_file(&format!("{}/{}", name, ".github/workflows/rustdoc.yml"));
     }


### PR DESCRIPTION
it's obnoxious to have new projects assign many changes to people who had nothing to do with the creation of the project.

right now @jam1garner is listed as having the most contributions to https://github.com/blu-dev/smashline_hook/graphs/contributors even though the only thing they contributed to the project was the ACMD language (which isn't even in that repository).