### PR TITLE
Allow for JSON output in check and clippy subcommands 

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ enum SubCommands {
         template_git_branch: String,
     },
     #[structopt(about = "Check if the current plugin builds and emit any errors found")]
-    Check,
+    Check {
+        #[structopt(long)]
+        json: bool,
+    },
     #[structopt(about = "Emit beginner-helpful lints and warnings")]
     Clippy {
         #[structopt(long)]
@@ -49,6 +52,9 @@ enum SubCommands {
 
         #[structopt(long)]
         no_default_features: bool,
+
+        #[structopt(long)]
+        json: bool,
 
         #[structopt(last = true)]
         opts: Vec<String>,
@@ -308,13 +314,14 @@ fn main() {
             features,
             no_default_features,
         } => build::build(args, release, nso, features, no_default_features),
-        Check => build::check(),
+        Check { json } => build::check(json),
         Clippy {
             no_deps,
             fix,
             features,
             all_features,
             no_default_features,
+            json,
             opts,
         } => {
             let mut args = Vec::new();
@@ -342,7 +349,7 @@ fn main() {
 
             args.extend(opts);
 
-            build::clippy(args)
+            build::clippy(args, json)
         }
         Run {
             ip,


### PR DESCRIPTION
I noticed `cargo-skyline v3.0.0` didn't really support rust-analyzer's check on save due to the build subcommand eating Cargo JSON output to be able to generate the NRO, and `check`/`clippy` using the same code.

Due to `cargo-skyline` already setting `--message-format=json-diagnostic-rendered-ansi` internally, and thus clippy failing with `error: cannot specify two kinds of message-format arguments` if you were to specify `-- --message-format=json`, I added a `--json` flag to both `check` and `clippy` which simply prints the JSON output that `.stdout(Stdio::piped())` supresses, allowing rust-analyzer to run off `cargo skyline check/clippy`.

...this in turn forced me to refactor how `cargo_run_command` on `build.rs` processes Cargo output, which in turn lead me to refactor `cargo_run_command` itself to just return `Result<Vec<Message>>` and move the last artifact extraction code one level up to `build_get_artifact` (the last artifact information is only used there anyway).

On the bright side, this refactor would allow to retrofit the `--json` flag into `cargo skyline build` in the future, since outputting the generated JSON should not interfere with extracting the final artifact anymore.