### PR TITLE
Implement packing resources in release.zip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,6 +227,7 @@ dependencies = [
  "structopt",
  "tokio",
  "url",
+ "walkdir",
  "zip",
 ]
 
@@ -1331,6 +1332,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,6 +1835,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,6 +1977,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ url = "2.2.2"
 reqwest = { version = "0.11", features = ["blocking", "rustls-tls"], default-features = false }
 indicatif = "0.16.0"
 dialoguer = "0.8.0"
+walkdir = "2.3.2"
 
 [features]
 debug = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 use crate::ftp::FtpError;
 use owo_colors::OwoColorize;
-use std::io;
+use std::{io, path::PathBuf};
 
 #[allow(clippy::enum_variant_names)]
 pub enum Error {
@@ -37,6 +37,7 @@ pub enum Error {
     NoBaseCommit,
     ProjectAlreadyExists,
     FailCreateProject,
+    PackageResourceMissing(PathBuf)
 }
 
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,7 @@ fn main() {
             Error::NoBaseCommit => eprintln!("{}: No base rust-src commit was found, cannot determined correct nightly.", error),
             Error::ProjectAlreadyExists => eprintln!("{}: a folder with that name already exists", error),
             Error::FailCreateProject => eprintln!("{}: project files could not be written to disk", error),
+            Error::PackageResourceMissing(path) => eprintln!("{}: Package resource '{}' specified in Cargo.toml not found at the specified path.", error, path.display()),
         }
 
         std::process::exit(1);


### PR DESCRIPTION
Adds a new metadata field "package-resources" for Cargo.toml to specify files and directories to be copied when using ``cargo skyline package``.

Example:
```toml

[package.metadata.skyline]
titleid = "01003cf0128de000" # Ar nosurge: Ode to an Unborn Star Deluxe
package-resources = [
    { local = "ModFiles/exefs", package = "atmosphere/contents/01003cf0128de000/exefs" },
    { local = "ModFiles/romfs", package = "atmosphere/contents/01003cf0128de000/romfs" },
]
```

Closes #24