### PR TITLE
Don't extract NPDM from the Skyline archive

### DIFF
--- a/src/package.rs
+++ b/src/package.rs
@@ -3,16 +3,15 @@ use crate::cargo_info;
 use crate::error::{Error, Result};
 use crate::game_paths::{get_npdm_path, get_plugin_nro_path, get_subsdk_path};
 use owo_colors::OwoColorize;
-use walkdir::WalkDir;
 use std::fs;
 use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::path::PathBuf;
 use std::result::Result as StdResult;
+use walkdir::WalkDir;
 use zip::{ZipArchive, ZipWriter};
 
 pub struct Exefs {
-    pub main_npdm: Vec<u8>,
     pub subsdk1: Vec<u8>,
 }
 
@@ -31,12 +30,8 @@ pub fn get_exefs(url: &str) -> Result<Exefs> {
         .by_name("exefs/subsdk9")?
         .bytes()
         .collect::<StdResult<_, _>>()?;
-    let main_npdm = zip
-        .by_name("exefs/main.npdm")?
-        .bytes()
-        .collect::<StdResult<_, _>>()?;
 
-    Ok(Exefs { main_npdm, subsdk1 })
+    Ok(Exefs { subsdk1 })
 }
 
 pub fn package(
@@ -111,24 +106,34 @@ pub fn package(
 
         if Path::new(&local_path).is_dir() {
             // Get all files in the directory and subdirectories
-            let paths: Vec<PathBuf> = WalkDir::new(&local_path).into_iter().flatten().filter(|entry| entry.file_type().is_file()).map(|entry| entry.path().to_owned()).collect();
+            let paths: Vec<PathBuf> = WalkDir::new(&local_path)
+                .into_iter()
+                .flatten()
+                .filter(|entry| entry.file_type().is_file())
+                .map(|entry| entry.path().to_owned())
+                .collect();
 
             for path in paths {
                 // Strip the local directory from the path we're processing and add the destination directory as prefix
                 zip.start_file(
-                    output_path.join(&path.strip_prefix(&local_path).unwrap()).to_str().unwrap(),
+                    output_path
+                        .join(&path.strip_prefix(&local_path).unwrap())
+                        .to_str()
+                        .unwrap(),
                     Default::default(),
                 )?;
-    
-                zip.write_all(&std::fs::read(&path).map_err(|_| Error::PackageResourceMissing(path))?)?;
+
+                zip.write_all(
+                    &std::fs::read(&path).map_err(|_| Error::PackageResourceMissing(path))?,
+                )?;
             }
         } else {
-            zip.start_file(
-                output_path.to_str().unwrap(),
-                Default::default(),
-            )?;
+            zip.start_file(output_path.to_str().unwrap(), Default::default())?;
 
-            zip.write_all(&std::fs::read(&local_path).map_err(|_| Error::PackageResourceMissing(local_path.to_owned()))?)?;
+            zip.write_all(
+                &std::fs::read(&local_path)
+                    .map_err(|_| Error::PackageResourceMissing(local_path.to_owned()))?,
+            )?;
         }
     }
 


### PR DESCRIPTION
The `main.npdm` file is extracted from the Skyline archive, but it is never actually used.  
If it is missing from the archive, however, it will throw an error. This is a problem once Skyline eventually supports more games, as it is likely that it will not distribute the NPDM file in the archive anymore.