### PR TITLE
Inform the user of GitHub errors (primarily for rate-limiting)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -24,7 +24,7 @@ pub enum Error {
     ExitStatus(i32),
     AbsSwitchPath,
     BadSdPath,
-    GithubError,
+    GithubError(octocrab::Error),
     //InvalidRepo,
     //HostNotSupported,
     DownloadFailed,
@@ -82,8 +82,8 @@ impl From<zip::result::ZipError> for Error {
 }
 
 impl From<octocrab::Error> for Error {
-    fn from(_: octocrab::Error) -> Self {
-        Self::GithubError
+    fn from(err: octocrab::Error) -> Self {
+        Self::GithubError(err)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -466,7 +466,7 @@ fn main() {
             Error::NoNpdmFileFound => eprintln!("{}: Custom NPDM file specified in Cargo.toml not found at the specified path.", error),
             Error::AbsSwitchPath => eprintln!("{}: Absolute Switch paths must be prepended with \"sd:/\"", error),
             Error::BadSdPath => eprintln!("{}: Install paths must either start with \"rom:/\" or \"sd:/\"", error),
-            Error::GithubError => eprintln!("{}: failed to get the latest release from github", error),
+            Error::GithubError(_) => eprintln!("{}: failed to get the latest release from github", error),
             //Error::InvalidRepo => eprintln!("{}: repos must be in the form of `{{user}}/{{repo}}`", error),
             //Error::HostNotSupported => eprintln!("{}: your host platform is not supported.", error),
             Error::DownloadFailed => eprintln!("{}: the update failed to download.", error),

--- a/src/update_std.rs
+++ b/src/update_std.rs
@@ -68,7 +68,17 @@ fn get_original_toolchain(
 
     let base_nightly = base_nightly.join().unwrap().map_err(|err| {
         base_nightly_progress.set_style(failed_style.clone());
-        base_nightly_progress.finish_with_message("Failed to get find base nightly");
+
+        if let Error::GithubError(oct_err) = &err {
+            if let octocrab::Error::GitHub {
+                source,
+                backtrace: _,
+            } = oct_err {
+                base_nightly_progress.finish_with_message(format!("Failed to get find base nightly: {}", source.message))
+            }
+        } else {
+            base_nightly_progress.finish_with_message("Failed to get find base nightly");
+        }
 
         err
     })?;


### PR DESCRIPTION
If the user is rate-limited (due to GitHub's new unauthenticated limits, simply opening an emulator too often can easily limit you) while trying to install/update the STD, the following error is currently displayed:

``❌ Failed to get find base nightly``

This change aims to print the actual error message to at least clarify what happened or ask for help.